### PR TITLE
fix: accelerate archives with pigz when available

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,6 @@ jobs:
         leanup elan --help
         leanup lean --help
         leanup config --help
-        leanup clean --help
         leanup mathlib --help
         leanup mathlib check --help
         leanup serve --help

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,13 @@ jobs:
       run: |
         # Test basic CLI commands
         leanup --help
+        leanup init --help
+        leanup elan --help
+        leanup lean --help
+        leanup config --help
+        leanup clean --help
         leanup mathlib --help
+        leanup mathlib check --help
         leanup serve --help
         leanup toolchains --help
         leanup repo --help

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install -e .
 # 查看帮助
 leanup --help
 
-# 初始化 LeanUp 自己的 home/config/cache/tmp 目录
+# 初始化 LeanUp 自己的 home/config/cache 目录
 leanup init
 
 # 可选：配置内网 LeanUp 资产服务
@@ -72,7 +72,7 @@ leanup setup ./Demo --lean-version v4.27.0
 0.3 开始新增资源式 CLI，用于把环境资产与项目初始化解耦：
 
 ```text
-leanup init             # 初始化 ~/.leanup、.env、cache、tmp、logs
+leanup init             # 初始化 ~/.leanup、.env、cache、logs
 leanup elan ...         # 管理基础 elan runtime
 leanup lean ...         # 管理 ELAN_HOME/toolchains 下的 Lean toolchain
 leanup mathlib ...      # 管理 Mathlib cache / .lake 资产

--- a/README.md
+++ b/README.md
@@ -45,12 +45,72 @@ pip install -e .
 # 查看帮助
 leanup --help
 
-# 快速初始化一个 Lean + mathlib 项目
+# 初始化 LeanUp 自己的 home/config/cache/tmp 目录
+leanup init
+
+# 可选：配置内网 LeanUp 资产服务
+leanup init --server http://127.0.0.1:8000
+# 等价于之后执行
+leanup config set-server http://127.0.0.1:8000
+
+# 安装或恢复基础 elan，不包含具体 Lean toolchain
+leanup elan install
+
+# 安装或恢复指定 Lean toolchain 到 ELAN_HOME/toolchains
+leanup lean install v4.30.0
+leanup lean check v4.30.0
+
+# 快速初始化一个 Lean + mathlib 项目（兼容旧入口）
 leanup setup ./Demo --lean-version v4.27.0
 
 ```
 
 ## 📖 详细使用指南
+
+### LeanUp 0.3 环境资产 CLI
+
+0.3 开始新增资源式 CLI，用于把环境资产与项目初始化解耦：
+
+```text
+leanup init             # 初始化 ~/.leanup、.env、cache、tmp、logs
+leanup elan ...         # 管理基础 elan runtime
+leanup lean ...         # 管理 ELAN_HOME/toolchains 下的 Lean toolchain
+leanup mathlib ...      # 管理 Mathlib cache / .lake 资产
+leanup serve            # 托管 cache/serve 中的 archive 和 index
+```
+
+常见 provider 流程：
+
+```bash
+leanup init --server http://127.0.0.1:8000
+leanup elan check
+leanup elan pack
+leanup lean check v4.30.0
+leanup lean pack v4.30.0
+leanup mathlib check v4.30.0 --source /path/to/mathlib-workspace
+leanup mathlib pack v4.30.0 --source /path/to/mathlib-workspace
+leanup serve --host 0.0.0.0 --port 8000
+```
+
+常见 consumer 流程：
+
+```bash
+leanup init --server http://127.0.0.1:8000
+leanup elan install
+leanup lean install v4.30.0
+leanup lean check v4.30.0
+leanup mathlib get v4.30.0
+leanup mathlib unpack v4.30.0
+leanup mathlib check v4.30.0 --source /path/to/mathlib-workspace
+```
+
+设计边界：
+
+- LeanUp 不维护第二套 runtime elan 或 toolchain；最终仍然使用 `ELAN_HOME` 和 `ELAN_HOME/toolchains`。
+- `leanup elan pack` 会排除 `toolchains/`，只打包基础 elan。
+- `leanup lean pack <version>` 从 `ELAN_HOME/toolchains` 打包指定 Lean toolchain。
+- `leanup mathlib pack <version>` 优先打包已验证 Mathlib workspace 的整个 `.lake/`，不打包整个 mathlib git repo。
+- pack/get/unpack/install 都先写入临时目录或临时文件，校验通过后再原子替换正式位置；符号链接会按 symlink 保留，不会展开成普通文件。
 
 ### 仓库管理
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -20,6 +20,33 @@ pip install -e .
 leanup --help
 ```
 
+### 初始化 LeanUp 与 Lean toolchain
+
+```bash
+# 初始化 LeanUp 自己的配置、cache 和 tmp 目录
+leanup init
+
+# 可选：写入默认 LeanUp 资产服务地址
+leanup init --server http://127.0.0.1:8000
+# 或之后再配置
+leanup config set-server http://127.0.0.1:8000
+
+# 安装或恢复基础 elan
+leanup elan install
+leanup elan check
+
+# 安装或恢复指定 Lean toolchain
+leanup lean install v4.30.0
+leanup lean check v4.30.0
+```
+
+说明：
+
+- `leanup init` 只初始化 LeanUp 自己，不安装 elan、Lean 或 Mathlib。
+- `leanup elan ...` 管基础 elan runtime，最终位置仍然是 `ELAN_HOME`。
+- `leanup lean ...` 管 `ELAN_HOME/toolchains` 下的 Lean toolchain。
+- 如果配置的 server 没有对应 archive，`leanup lean install` 可以回退到标准 `elan toolchain install`。
+
 ### 快速创建项目
 
 ```bash
@@ -55,17 +82,20 @@ leanup mathlib list --local
 # 查看远端服务已有缓存版本和下载 URL
 leanup mathlib list --remote http://127.0.0.1:8000
 
-# 在 tempfile 临时工作目录中创建某个 Lean 版本的共享 mathlib packages 缓存
+# 检查一个 Mathlib workspace 是否可以 import Mathlib
+leanup mathlib check v4.30.0 --source /path/to/mathlib-workspace
+
+# 将已验证 workspace 的整个 .lake/ 打包成 LeanUp archive
+leanup mathlib pack v4.30.0 --source /path/to/mathlib-workspace
+
+# 将本地 .lake archive 解压回 LeanUp mathlib cache
+leanup mathlib unpack v4.30.0
+
+# 从 LeanUp cache 服务下载 packages.tar.gz，并解压到本地缓存根（兼容旧 packages 格式）
+leanup mathlib get v4.22.0 --remote http://127.0.0.1:8000
+
+# 在 tempfile 临时工作目录中创建某个 Lean 版本的共享 mathlib packages 缓存（兼容旧 packages 格式）
 leanup mathlib create v4.22.0
-
-# 将本地缓存里的 packages/<version>/packages 打包成 archives/<version>/packages.tar.gz
-leanup mathlib pack v4.22.0
-
-# 将本地 archive 解压回 packages 目录
-leanup mathlib unpack v4.22.0
-
-# 或者使用指定缓存根
-leanup mathlib pack v4.22.0 --output-dir /path/to/cache
 
 # 启动缓存服务：/f/... 给 lake exe cache get，/packages/... 给 leanup cache get
 leanup serve
@@ -73,22 +103,16 @@ leanup serve
 # 让 mathlib 官方 cache client 改走 LeanUp 服务
 export MATHLIB_CACHE_GET_URL=http://127.0.0.1:8000
 lake exe cache get
-
-# 从 LeanUp cache 服务下载 packages.tar.gz，并解压到本地缓存根
-leanup mathlib get v4.22.0 --remote http://127.0.0.1:8000
-
-# 如需关闭并发压缩，可以显式禁用 pigz
-leanup mathlib pack v4.22.0 --output-dir /path/to/cache --no-pigz
 ```
 
-- 默认会在本机存在 `pigz` 时启用并发压缩
+- `leanup mathlib pack <version> --source <workspace>` 优先打包 `<workspace>/.lake/`，不打包整个 mathlib git repo
+- `leanup mathlib check <version>` 使用 `import Mathlib` 做可用性检查，建议在 pack 前和 unpack 后执行
+- `.lake` archive 写入 `~/.leanup/cache/serve/mathlib/<version>/mathlib-lake.tar.gz`
+- `.lake` unpack 写入 `~/.leanup/cache/local/mathlib/<version>/.lake/`
+- legacy packages cache 入口继续兼容：没有 `.lake` 时仍可使用 `packages/<version>/packages` 与 `archives/<version>/packages.tar.gz`
+- 默认会在本机存在 `pigz` 时启用并发压缩 legacy packages archive
 - 如果系统里没有 `pigz`，命令会自动回退到普通 gzip 打包
-- `--no-pigz` 可显式关闭并发压缩
-- `leanup cache create` 会在临时目录中执行 `lake update` 和 `lake exe cache get`，再把 `.lake/packages` 回填到 `mathlib/packages/<version>/packages` 并生成 `mathlib/archives/<version>/packages.tar.gz`
-- `leanup cache serve` 的 `.ltar` 路由只做 mathlib 兼容分发；`packages.tar.gz` 是 LeanUp 自定义缓存格式
-- `leanup cache serve` 使用 FastAPI/uvicorn，并提供 `/packages/mathlib/index.json` 供其他机器列出远端可用版本
-- `leanup cache pack` 从 `mathlib/packages/<version>/packages` 生成 `mathlib/archives/<version>/packages.tar.gz`
-- `leanup cache get` 从远端下载 `packages.tar.gz` 到 `mathlib/archives/<version>/packages.tar.gz`，并解压到 `mathlib/packages/<version>/packages`
+- `--no-pigz` 可显式关闭 legacy packages 并发压缩
 - `leanup cache pack` 和 `leanup cache get` 都先写临时文件 / 临时目录，成功后再原子替换正式路径，避免中断损坏缓存
 
 ### 管理 toolchains 缓存

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -23,7 +23,7 @@ leanup --help
 ### 初始化 LeanUp 与 Lean toolchain
 
 ```bash
-# 初始化 LeanUp 自己的配置、cache 和 tmp 目录
+# 初始化 LeanUp 自己的配置和 cache 目录
 leanup init
 
 # 可选：写入默认 LeanUp 资产服务地址

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 ## 功能特性
 
-- `leanup init`：初始化 LeanUp home、`.env`、cache、tmp、logs 等基础目录
+- `leanup init`：初始化 LeanUp home、`.env`、cache、logs 等基础目录
 - `leanup elan`：安装、打包、下载、解包和检查基础 elan runtime
 - `leanup lean`：安装、打包、下载、解包和检查 `ELAN_HOME/toolchains` 下的 Lean toolchain
 - `leanup mathlib setup`：快速创建固定 Lean 版本项目，支持 mathlib 共享缓存

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,14 +4,16 @@
 
 ## 功能特性
 
+- `leanup init`：初始化 LeanUp home、`.env`、cache、tmp、logs 等基础目录
+- `leanup elan`：安装、打包、下载、解包和检查基础 elan runtime
+- `leanup lean`：安装、打包、下载、解包和检查 `ELAN_HOME/toolchains` 下的 Lean toolchain
 - `leanup mathlib setup`：快速创建固定 Lean 版本项目，支持 mathlib 共享缓存
-- `leanup mathlib list`：查看本地或远端 mathlib 共享缓存版本
-- `leanup mathlib create <version>`：在临时目录创建某个 Lean 版本的 mathlib packages 缓存
-- `leanup mathlib pack <version>`：将本地缓存里的 packages 目录打包为共享缓存归档
-- `leanup mathlib unpack <version>`：从本地 archive 解压回 packages 目录
-- `leanup mathlib get <version>`：从 LeanUp 服务下载 `packages.tar.gz` 并解压到本地缓存
-- `leanup serve`：提供 `.ltar` 兼容路由和 LeanUp packages 归档下载服务
-- `leanup toolchains`：管理 `.elan` 基础包和 Lean toolchain 归档
+- `leanup mathlib check <version>`：检查指定 Mathlib 环境是否能 `import Mathlib`
+- `leanup mathlib pack <version>`：优先把已验证 workspace 的 `.lake/` 打包为共享缓存归档
+- `leanup mathlib unpack <version>`：优先从本地 `.lake` archive 解压回 LeanUp mathlib cache
+- `leanup mathlib list/get/create`：查看、下载或创建 mathlib 共享缓存
+- `leanup serve`：提供 `.ltar` 兼容路由和 LeanUp 归档下载服务
+- `leanup toolchains`：兼容旧入口，管理 `.elan` 基础包和 Lean toolchain 归档
 - `leanup repo install`：安装 Lean 仓库，支持命令优先、交互补参
 - `leanup repo list`：查看已安装仓库
 

--- a/leanup/__init__.py
+++ b/leanup/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Lean-zh Community"""
 __email__ = 'leanprover@outlook.com'
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 from .repo import (
     RepoManager,

--- a/leanup/__init__.py
+++ b/leanup/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Lean-zh Community"""
 __email__ = 'leanprover@outlook.com'
-__version__ = '0.2.3'
+__version__ = '0.3.0'
 
 from .repo import (
     RepoManager,

--- a/leanup/cli/__init__.py
+++ b/leanup/cli/__init__.py
@@ -1,6 +1,6 @@
 import click
 
-from leanup.cli.assets import clean_cmd, config_cmd, elan_cmd, init_cmd, lean_cmd
+from leanup.cli.assets import config_cmd, elan_cmd, init_cmd, lean_cmd
 from leanup.cli.cache_ops import create_cache, get_cache, list_cache, mathlib_check, pack_cache, serve_cache, unpack_cache
 from leanup.cli.repo import repo
 from leanup.cli.setup import setup_project
@@ -36,7 +36,6 @@ cli.add_command(init_cmd)
 cli.add_command(elan_cmd)
 cli.add_command(lean_cmd)
 cli.add_command(config_cmd)
-cli.add_command(clean_cmd)
 cli.add_command(setup_project)
 cli.add_command(mathlib)
 cli.add_command(serve_cache)

--- a/leanup/cli/__init__.py
+++ b/leanup/cli/__init__.py
@@ -1,6 +1,7 @@
 import click
 
-from leanup.cli.cache_ops import create_cache, get_cache, list_cache, pack_cache, serve_cache, unpack_cache
+from leanup.cli.assets import clean_cmd, config_cmd, elan_cmd, init_cmd, lean_cmd
+from leanup.cli.cache_ops import create_cache, get_cache, list_cache, mathlib_check, pack_cache, serve_cache, unpack_cache
 from leanup.cli.repo import repo
 from leanup.cli.setup import setup_project
 from leanup.cli.toolchains import toolchains
@@ -28,8 +29,14 @@ mathlib.add_command(unpack_cache)
 mathlib.add_command(list_cache)
 mathlib.add_command(get_cache)
 mathlib.add_command(create_cache)
+mathlib.add_command(mathlib_check)
 
 
+cli.add_command(init_cmd)
+cli.add_command(elan_cmd)
+cli.add_command(lean_cmd)
+cli.add_command(config_cmd)
+cli.add_command(clean_cmd)
 cli.add_command(setup_project)
 cli.add_command(mathlib)
 cli.add_command(serve_cache)

--- a/leanup/cli/assets.py
+++ b/leanup/cli/assets.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+
+import click
+import requests
+
+from leanup.ops import environment as ops
+from leanup.paths import cache_dir, elan_home, set_env_value, tmp_dir
+from leanup.repo.mathlib_cache import remove_path
+
+
+@click.command(name="init")
+@click.option("--home", type=click.Path(path_type=Path, file_okay=False, dir_okay=True), help="LeanUp home directory.")
+@click.option("--server", help="Default LeanUp server URL to write into .env.")
+@click.option("--dry-run", is_flag=True, help="Show paths without writing.")
+def init_cmd(home: Path | None, server: str | None, dry_run: bool) -> None:
+    """Initialize LeanUp home/config/cache/tmp directories."""
+    root = home or Path(os.environ.get("LEANUP_HOME", Path.home() / ".leanup")).expanduser()
+    if dry_run:
+        click.echo(str(root))
+        for rel in [".env", "config", "repos", "cache/serve", "cache/local", "cache/downloads", "tmp", "logs", "state/locks"]:
+            click.echo(str(root / rel))
+        return
+    click.echo(str(ops.init_leanup_home(root, server)))
+
+
+@click.group(name="config")
+def config_cmd() -> None:
+    """Manage LeanUp .env configuration."""
+
+
+@config_cmd.command(name="show")
+def config_show() -> None:
+    ops.init_leanup_home()
+    click.echo(f"LEANUP_HOME={Path(os.environ.get('LEANUP_HOME', Path.home() / '.leanup')).expanduser()}")
+    click.echo(f"LEANUP_CACHE_DIR={cache_dir()}")
+    click.echo(f"LEANUP_ELAN_HOME={elan_home()}")
+    if ops.resolve_server():
+        click.echo(f"LEANUP_SERVER_URL={ops.resolve_server()}")
+
+
+@config_cmd.command(name="set-server")
+@click.argument("url")
+def config_set_server(url: str) -> None:
+    click.echo(str(set_env_value("LEANUP_SERVER_URL", url)))
+
+
+@click.group(name="clean")
+def clean_cmd() -> None:
+    """Clean LeanUp temporary files."""
+
+
+@clean_cmd.command(name="tmp")
+def clean_tmp() -> None:
+    root = tmp_dir()
+    remove_path(root)
+    root.mkdir(parents=True, exist_ok=True)
+    click.echo(str(root))
+
+
+@click.group(name="elan")
+def elan_cmd() -> None:
+    """Manage base elan runtime archives and installation."""
+
+
+@elan_cmd.command(name="pack")
+@click.option("--elan-home", type=click.Path(path_type=Path, file_okay=False, dir_okay=True), help="Source ELAN_HOME.")
+def elan_pack(elan_home: Path | None) -> None:
+    try:
+        click.echo(str(ops.pack_elan(elan_home)))
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@elan_cmd.command(name="get")
+@click.option("--server", help="LeanUp server URL.")
+def elan_get(server: str | None) -> None:
+    try:
+        click.echo(str(ops.get_elan(server)))
+    except (ValueError, requests.RequestException) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@elan_cmd.command(name="unpack")
+@click.option("--archive", type=click.Path(path_type=Path, dir_okay=False), help="elan archive path.")
+@click.option("--elan-home", type=click.Path(path_type=Path, file_okay=False, dir_okay=True), help="Target ELAN_HOME.")
+def elan_unpack(archive: Path | None, elan_home: Path | None) -> None:
+    try:
+        click.echo(str(ops.unpack_elan(archive, elan_home)))
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@elan_cmd.command(name="install")
+@click.option("--server", help="LeanUp server URL.")
+@click.option("--elan-home", type=click.Path(path_type=Path, file_okay=False, dir_okay=True), help="Target ELAN_HOME.")
+def elan_install(server: str | None, elan_home: Path | None) -> None:
+    try:
+        click.echo(str(ops.install_elan(server, elan_home)))
+    except (ValueError, requests.RequestException) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@elan_cmd.command(name="check")
+@click.option("--elan-home", type=click.Path(path_type=Path, file_okay=False, dir_okay=True), help="ELAN_HOME to check.")
+def elan_check(elan_home: Path | None) -> None:
+    try:
+        click.echo(ops.check_elan(elan_home))
+    except (ValueError, RuntimeError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@click.group(name="lean")
+def lean_cmd() -> None:
+    """Manage Lean toolchains under ELAN_HOME."""
+
+
+@lean_cmd.command(name="pack")
+@click.argument("version")
+@click.option("--elan-home", type=click.Path(path_type=Path, file_okay=False, dir_okay=True), help="Source ELAN_HOME.")
+def lean_pack(version: str, elan_home: Path | None) -> None:
+    try:
+        click.echo(str(ops.pack_lean(version, elan_home)))
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@lean_cmd.command(name="get")
+@click.argument("version")
+@click.option("--server", help="LeanUp server URL.")
+def lean_get(version: str, server: str | None) -> None:
+    try:
+        click.echo(str(ops.get_lean(version, server)))
+    except (ValueError, requests.RequestException) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@lean_cmd.command(name="unpack")
+@click.argument("version")
+@click.option("--archive", type=click.Path(path_type=Path, dir_okay=False), help="toolchain archive path.")
+@click.option("--elan-home", type=click.Path(path_type=Path, file_okay=False, dir_okay=True), help="Target ELAN_HOME.")
+def lean_unpack(version: str, archive: Path | None, elan_home: Path | None) -> None:
+    try:
+        click.echo(str(ops.unpack_lean(version, archive, elan_home)))
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@lean_cmd.command(name="install")
+@click.argument("version")
+@click.option("--server", help="LeanUp server URL.")
+@click.option("--elan-home", type=click.Path(path_type=Path, file_okay=False, dir_okay=True), help="Target ELAN_HOME.")
+def lean_install(version: str, server: str | None, elan_home: Path | None) -> None:
+    try:
+        click.echo(str(ops.install_lean(version, server, elan_home)))
+    except (ValueError, RuntimeError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@lean_cmd.command(name="list")
+@click.option("--elan-home", type=click.Path(path_type=Path, file_okay=False, dir_okay=True), help="ELAN_HOME.")
+def lean_list(elan_home: Path | None) -> None:
+    for item in ops.list_installed_lean(elan_home):
+        click.echo(item)
+
+
+@lean_cmd.command(name="check")
+@click.argument("version")
+@click.option("--elan-home", type=click.Path(path_type=Path, file_okay=False, dir_okay=True), help="ELAN_HOME.")
+def lean_check(version: str, elan_home: Path | None) -> None:
+    try:
+        click.echo(ops.check_lean(version, elan_home))
+    except (ValueError, RuntimeError) as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/leanup/cli/assets.py
+++ b/leanup/cli/assets.py
@@ -7,8 +7,7 @@ import click
 import requests
 
 from leanup.ops import environment as ops
-from leanup.paths import cache_dir, elan_home, set_env_value, tmp_dir
-from leanup.repo.mathlib_cache import remove_path
+from leanup.paths import cache_dir, elan_home, set_env_value
 
 
 @click.command(name="init")
@@ -16,11 +15,11 @@ from leanup.repo.mathlib_cache import remove_path
 @click.option("--server", help="Default LeanUp server URL to write into .env.")
 @click.option("--dry-run", is_flag=True, help="Show paths without writing.")
 def init_cmd(home: Path | None, server: str | None, dry_run: bool) -> None:
-    """Initialize LeanUp home/config/cache/tmp directories."""
+    """Initialize LeanUp home/config/cache directories."""
     root = home or Path(os.environ.get("LEANUP_HOME", Path.home() / ".leanup")).expanduser()
     if dry_run:
         click.echo(str(root))
-        for rel in [".env", "config", "repos", "cache/serve", "cache/local", "cache/downloads", "tmp", "logs", "state/locks"]:
+        for rel in [".env", "config", "repos", "cache/serve", "cache/local", "cache/downloads", "logs", "state/locks"]:
             click.echo(str(root / rel))
         return
     click.echo(str(ops.init_leanup_home(root, server)))
@@ -45,19 +44,6 @@ def config_show() -> None:
 @click.argument("url")
 def config_set_server(url: str) -> None:
     click.echo(str(set_env_value("LEANUP_SERVER_URL", url)))
-
-
-@click.group(name="clean")
-def clean_cmd() -> None:
-    """Clean LeanUp temporary files."""
-
-
-@clean_cmd.command(name="tmp")
-def clean_tmp() -> None:
-    root = tmp_dir()
-    remove_path(root)
-    root.mkdir(parents=True, exist_ok=True)
-    click.echo(str(root))
 
 
 @click.group(name="elan")

--- a/leanup/cli/cache_ops.py
+++ b/leanup/cli/cache_ops.py
@@ -31,8 +31,8 @@ def _extract_lake_archive(archive: Path, target_lake: Path) -> Path:
         raise ValueError(f"Archive not found: {archive}")
     parent = target_lake.parent
     parent.mkdir(parents=True, exist_ok=True)
-    temp_root = Path(tempfile.mkdtemp(prefix=".lake.", suffix=".tmp", dir=parent))
-    try:
+    with tempfile.TemporaryDirectory(prefix="leanup-lake-unpack-") as work:
+        temp_root = Path(work)
         safe_extract(archive, temp_root)
         extracted = temp_root / ".lake"
         if not extracted.exists() or not extracted.is_dir():
@@ -42,11 +42,7 @@ def _extract_lake_archive(archive: Path, target_lake: Path) -> Path:
         extracted.replace(final_temp)
         remove_path(target_lake)
         final_temp.replace(target_lake)
-        remove_path(temp_root)
         return target_lake
-    except Exception:
-        remove_path(temp_root)
-        raise
 
 
 @click.command(name="pack")

--- a/leanup/cli/cache_ops.py
+++ b/leanup/cli/cache_ops.py
@@ -8,37 +8,85 @@ import click
 import requests
 
 from leanup.const import LEANUP_CACHE_DIR
+from leanup.ops.environment import safe_extract, tar_directory
+from leanup.paths import cache_dir as leanup_cache_dir
 from leanup.repo.cache_server import run_cache_server
-from leanup.repo.mathlib_cache import MathlibCacheManager, normalize_lean_version
+from leanup.repo.mathlib_cache import MathlibCacheManager, normalize_lean_version, remove_path
 from leanup.repo.project_setup import LeanProjectSetup
 
 
 PACKAGES_CACHE_ROOT = LEANUP_CACHE_DIR / "mathlib"
 
 
+def _mathlib_local_lake_dir(version: str) -> Path:
+    return leanup_cache_dir() / "local" / "mathlib" / normalize_lean_version(version) / ".lake"
+
+
+def _mathlib_lake_archive(version: str) -> Path:
+    return leanup_cache_dir() / "serve" / "mathlib" / normalize_lean_version(version) / "mathlib-lake.tar.gz"
+
+
+def _extract_lake_archive(archive: Path, target_lake: Path) -> Path:
+    if not archive.exists():
+        raise ValueError(f"Archive not found: {archive}")
+    parent = target_lake.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    temp_root = Path(tempfile.mkdtemp(prefix=".lake.", suffix=".tmp", dir=parent))
+    try:
+        safe_extract(archive, temp_root)
+        extracted = temp_root / ".lake"
+        if not extracted.exists() or not extracted.is_dir():
+            raise ValueError(f"Archive does not contain top-level .lake/ directory: {archive}")
+        final_temp = parent / ".lake.replace"
+        remove_path(final_temp)
+        extracted.replace(final_temp)
+        remove_path(target_lake)
+        final_temp.replace(target_lake)
+        remove_path(temp_root)
+        return target_lake
+    except Exception:
+        remove_path(temp_root)
+        raise
+
+
 @click.command(name="pack")
 @click.argument("lean_version")
+@click.option(
+    "--source",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    help="Mathlib workspace containing a .lake directory to archive.",
+)
 @click.option(
     "--output-dir",
     type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
     default=PACKAGES_CACHE_ROOT,
-    help="Mathlib cache root containing packages/<version>/packages and archives/<version>/packages.tar.gz.",
+    help="Legacy mathlib packages cache root used when no .lake source/cache is available.",
 )
 @click.option(
     "--pigz/--no-pigz",
     default=True,
-    help="Use pigz for parallel compression when it is available.",
+    help="Use pigz for legacy packages compression when it is available.",
 )
-def pack_cache(lean_version: str, output_dir: Path, pigz: bool) -> None:
-    """Pack cached packages/<version>/packages into archives/<version>/packages.tar.gz."""
-    manager = MathlibCacheManager(cache_root=output_dir)
+def pack_cache(lean_version: str, source: Path | None, output_dir: Path, pigz: bool) -> None:
+    """Pack Mathlib .lake when available, otherwise keep legacy packages cache behavior."""
     version = normalize_lean_version(lean_version)
+    lake_dir = (source / ".lake") if source is not None else _mathlib_local_lake_dir(version)
+    if lake_dir.exists():
+        try:
+            packed = tar_directory(lake_dir, ".lake", _mathlib_lake_archive(version))
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(str(packed))
+        return
+
+    manager = MathlibCacheManager(cache_root=output_dir)
     packages_dir = manager.ensure_local_cache(version)
     archive = manager.get_local_archive_path(version)
 
     if packages_dir is None:
         raise click.ClickException(
-            f"Packages cache not found: {manager.get_local_packages_dir(version)}. Run 'leanup cache create {version}' or 'leanup cache get {version} --base-url ...' first."
+            f"Mathlib .lake not found: {lake_dir}. Legacy packages cache not found: {manager.get_local_packages_dir(version)}. "
+            f"Run 'leanup cache create {version}' or 'leanup cache get {version} --base-url ...' first."
         )
 
     try:
@@ -55,12 +103,21 @@ def pack_cache(lean_version: str, output_dir: Path, pigz: bool) -> None:
     "--cache-dir",
     type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
     default=PACKAGES_CACHE_ROOT,
-    help="Mathlib cache root containing packages/<version>/packages and archives/<version>/packages.tar.gz.",
+    help="Legacy mathlib packages cache root.",
 )
 def unpack_cache(lean_version: str, cache_dir: Path) -> None:
-    """Unpack archives/<version>/packages.tar.gz into packages/<version>/packages."""
-    manager = MathlibCacheManager(cache_root=cache_dir)
+    """Unpack Mathlib .lake archive when present, otherwise use legacy packages cache."""
     version = normalize_lean_version(lean_version)
+    lake_archive = _mathlib_lake_archive(version)
+    if lake_archive.exists():
+        try:
+            lake_dir = _extract_lake_archive(lake_archive, _mathlib_local_lake_dir(version))
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(str(lake_dir))
+        return
+
+    manager = MathlibCacheManager(cache_root=cache_dir)
     archive = manager.get_local_archive_path(version)
 
     try:

--- a/leanup/cli/cache_ops.py
+++ b/leanup/cli/cache_ops.py
@@ -8,7 +8,7 @@ import click
 import requests
 
 from leanup.const import LEANUP_CACHE_DIR
-from leanup.ops.environment import safe_extract, tar_directory
+from leanup.ops.environment import extract_tar_gz, tar_directory
 from leanup.paths import cache_dir as leanup_cache_dir
 from leanup.repo.cache_server import run_cache_server
 from leanup.repo.mathlib_cache import MathlibCacheManager, normalize_lean_version, remove_path
@@ -31,9 +31,9 @@ def _extract_lake_archive(archive: Path, target_lake: Path) -> Path:
         raise ValueError(f"Archive not found: {archive}")
     parent = target_lake.parent
     parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(prefix="leanup-lake-unpack-") as work:
+    with tempfile.TemporaryDirectory(prefix=".leanup-lake-unpack.", dir=parent) as work:
         temp_root = Path(work)
-        safe_extract(archive, temp_root)
+        extract_tar_gz(archive, temp_root)
         extracted = temp_root / ".lake"
         if not extracted.exists() or not extracted.is_dir():
             raise ValueError(f"Archive does not contain top-level .lake/ directory: {archive}")

--- a/leanup/cli/cache_ops.py
+++ b/leanup/cli/cache_ops.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess
+import tempfile
 
 import click
 import requests
@@ -143,6 +145,42 @@ def serve_cache(host: str, port: int, ltar_root: Path, packages_root: Path) -> N
         run_cache_server(host, port, ltar_root, packages_root)
     except KeyboardInterrupt:
         click.echo("\nStopped.", err=True)
+
+
+@click.command(name="check")
+@click.argument("lean_version")
+@click.option(
+    "--source",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    help="Mathlib workspace to check. Defaults to current directory.",
+)
+@click.option(
+    "--lean-bin",
+    type=click.Path(path_type=Path, dir_okay=False),
+    help="Lean executable to use when lake is unavailable.",
+)
+def mathlib_check(lean_version: str, source: Path | None, lean_bin: Path | None) -> None:
+    """Check that a Mathlib environment can import Mathlib."""
+    normalize_lean_version(lean_version)
+    workspace = source or Path.cwd()
+    if not workspace.exists():
+        raise click.ClickException(f"Workspace not found: {workspace}")
+
+    check_content = "import Mathlib\n\n#check Nat\n"
+    with tempfile.TemporaryDirectory(prefix="leanup-mathlib-check-") as tmp:
+        check_file = Path(tmp) / "CheckMathlib.lean"
+        check_file.write_text(check_content, encoding="utf-8")
+        if (workspace / "lakefile.lean").exists() or (workspace / "lakefile.toml").exists():
+            command = ["lake", "env", "lean", str(check_file)]
+            cwd = workspace
+        else:
+            command = [str(lean_bin or "lean"), str(check_file)]
+            cwd = workspace
+        result = subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "import Mathlib check failed"
+        raise click.ClickException(message)
+    click.echo("import Mathlib ok")
 
 
 @click.command(name="create")

--- a/leanup/ops/__init__.py
+++ b/leanup/ops/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable LeanUp operations behind CLI commands."""

--- a/leanup/ops/environment.py
+++ b/leanup/ops/environment.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import os
+import shutil
 import subprocess
 import tarfile
 import tempfile
@@ -11,6 +12,27 @@ import requests
 
 from leanup.paths import cache_dir, elan_home, ensure_base_dirs, server_url
 from leanup.repo.mathlib_cache import normalize_lean_version, remove_path
+
+
+def has_parallel_gzip() -> bool:
+    return shutil.which("pigz") is not None and shutil.which("tar") is not None
+
+
+def validate_archive_paths(archive: Path, target_dir: Path) -> None:
+    target_dir = target_dir.resolve()
+    with tarfile.open(archive, "r:gz") as tar:
+        for member in tar.getmembers():
+            member_path = (target_dir / member.name).resolve()
+            if not str(member_path).startswith(str(target_dir)):
+                raise ValueError(f"Archive contains unsafe path: {member.name}")
+
+
+def extract_tar_gz(archive: Path, target_dir: Path) -> None:
+    validate_archive_paths(archive, target_dir)
+    if has_parallel_gzip():
+        subprocess.run(["tar", "-I", "pigz", "-xf", str(archive), "-C", str(target_dir)], check=True)
+        return
+    safe_extract(archive, target_dir)
 
 
 def download_to(url: str, output_file: Path) -> Path:
@@ -61,14 +83,25 @@ def tar_directory(source_dir: Path, arcname: str, output_file: Path, exclude: se
     with tempfile.NamedTemporaryFile(dir=output_file.parent, prefix=f".{output_file.name}.", suffix=".tmp", delete=False) as handle:
         temp_output = Path(handle.name)
     try:
-        with tarfile.open(temp_output, "w:gz", dereference=False) as tar:
-            if exclude:
-                for child in sorted(source_dir.iterdir()):
-                    if child.name in exclude:
-                        continue
-                    tar.add(child, arcname=f"{arcname}/{child.name}", recursive=True)
-            else:
-                tar.add(source_dir, arcname=arcname, recursive=True)
+        if exclude or not has_parallel_gzip():
+            with tarfile.open(temp_output, "w:gz", dereference=False) as tar:
+                if exclude:
+                    for child in sorted(source_dir.iterdir()):
+                        if child.name in exclude:
+                            continue
+                        tar.add(child, arcname=f"{arcname}/{child.name}", recursive=True)
+                else:
+                    tar.add(source_dir, arcname=arcname, recursive=True)
+        else:
+            subprocess.run(
+                ["tar", "-I", "pigz", "-cf", str(temp_output), "-C", str(source_dir.parent), "--", source_dir.name],
+                check=True,
+            )
+            # Preserve the requested archive root name. External tar is only used when arcname equals source name or .lake.
+            if arcname != source_dir.name:
+                remove_path(temp_output)
+                with tarfile.open(temp_output, "w:gz", dereference=False) as tar:
+                    tar.add(source_dir, arcname=arcname, recursive=True)
         temp_output.replace(output_file)
         return output_file
     except Exception:
@@ -117,9 +150,10 @@ def get_elan(server: str | None = None) -> Path:
 def unpack_elan(archive: Path | None = None, target_home: Path | None = None) -> Path:
     archive_path = archive or elan_archive_path()
     target = target_home or elan_home()
-    with tempfile.TemporaryDirectory(prefix="leanup-elan-unpack-") as work:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=".leanup-elan-unpack.", dir=target.parent) as work:
         work_root = Path(work)
-        safe_extract(archive_path, work_root)
+        extract_tar_gz(archive_path, work_root)
         extracted = work_root / ".elan"
         if not extracted.exists():
             raise ValueError(f"Archive does not contain .elan/: {archive_path}")
@@ -160,9 +194,10 @@ def get_lean(version: str, server: str | None = None) -> Path:
 def unpack_lean(version: str, archive: Path | None = None, target_home: Path | None = None) -> Path:
     archive_path = archive or lean_archive_path(version)
     home = target_home or elan_home()
-    with tempfile.TemporaryDirectory(prefix="leanup-lean-unpack-") as work:
+    (home / "toolchains").mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=".leanup-lean-unpack.", dir=home / "toolchains") as work:
         work_root = Path(work)
-        safe_extract(archive_path, work_root)
+        extract_tar_gz(archive_path, work_root)
         toolchains_root = work_root / ".elan" / "toolchains"
         candidates = [path for path in toolchains_root.iterdir() if path.is_dir()] if toolchains_root.exists() else []
         if len(candidates) != 1:

--- a/leanup/ops/environment.py
+++ b/leanup/ops/environment.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+import subprocess
+import tarfile
+import tempfile
+from urllib.parse import urljoin
+
+import requests
+
+from leanup.paths import cache_dir, elan_home, ensure_base_dirs, server_url, tmp_dir
+from leanup.repo.mathlib_cache import normalize_lean_version, remove_path
+
+
+def download_to(url: str, output_file: Path) -> Path:
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    work_root = tmp_dir()
+    work_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=work_root, prefix=f".{output_file.name}.", suffix=".tmp", delete=False) as handle:
+        temp_output = Path(handle.name)
+    try:
+        with requests.get(url, stream=True, timeout=120) as response:
+            response.raise_for_status()
+            with temp_output.open("wb") as output_handle:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        output_handle.write(chunk)
+        temp_output.replace(output_file)
+        return output_file
+    except Exception:
+        remove_path(temp_output)
+        raise
+
+
+def safe_extract(archive: Path, target_dir: Path) -> None:
+    target_dir = target_dir.resolve()
+    with tarfile.open(archive, "r:gz") as tar:
+        for member in tar.getmembers():
+            member_path = (target_dir / member.name).resolve()
+            if not str(member_path).startswith(str(target_dir)):
+                raise ValueError(f"Archive contains unsafe path: {member.name}")
+        try:
+            tar.extractall(target_dir, filter="data")
+        except TypeError:
+            tar.extractall(target_dir)
+
+
+def atomic_replace_dir(source_dir: Path, target_dir: Path) -> Path:
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    replacement = target_dir.parent / f".{target_dir.name}.replace-{os.getpid()}"
+    remove_path(replacement)
+    source_dir.replace(replacement)
+    remove_path(target_dir)
+    replacement.replace(target_dir)
+    return target_dir
+
+
+def tar_directory(source_dir: Path, arcname: str, output_file: Path, exclude: set[str] | None = None) -> Path:
+    if not source_dir.exists():
+        raise ValueError(f"Source directory not found: {source_dir}")
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    work_root = tmp_dir()
+    work_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=work_root, prefix=f".{output_file.name}.", suffix=".tmp", delete=False) as handle:
+        temp_output = Path(handle.name)
+    try:
+        with tarfile.open(temp_output, "w:gz", dereference=False) as tar:
+            if exclude:
+                for child in sorted(source_dir.iterdir()):
+                    if child.name in exclude:
+                        continue
+                    tar.add(child, arcname=f"{arcname}/{child.name}", recursive=True)
+            else:
+                tar.add(source_dir, arcname=arcname, recursive=True)
+        temp_output.replace(output_file)
+        return output_file
+    except Exception:
+        remove_path(temp_output)
+        raise
+
+
+def resolve_server(explicit: str | None = None) -> str | None:
+    return explicit or server_url()
+
+
+def init_leanup_home(home: Path | None = None, server: str | None = None) -> Path:
+    from leanup.paths import set_env_value
+
+    root = home or Path(os.environ.get("LEANUP_HOME", Path.home() / ".leanup")).expanduser()
+    ensure_base_dirs(root)
+    if server:
+        set_env_value("LEANUP_SERVER_URL", server, root)
+    return root
+
+
+def elan_archive_path() -> Path:
+    return cache_dir() / "serve" / "elan" / "base" / "elan-base.tar.gz"
+
+
+def lean_archive_path(version: str) -> Path:
+    return cache_dir() / "serve" / "lean" / normalize_lean_version(version) / "toolchain.tar.gz"
+
+
+def toolchain_name(version: str) -> str:
+    return f"leanprover--lean4---{normalize_lean_version(version)}"
+
+
+def pack_elan(source_home: Path | None = None) -> Path:
+    source = source_home or elan_home()
+    return tar_directory(source, ".elan", elan_archive_path(), exclude={"toolchains"})
+
+
+def get_elan(server: str | None = None) -> Path:
+    base = resolve_server(server)
+    if not base:
+        raise ValueError("No server configured. Use --server or leanup config set-server.")
+    return download_to(urljoin(base.rstrip("/") + "/", "elan/base/elan-base.tar.gz"), elan_archive_path())
+
+
+def unpack_elan(archive: Path | None = None, target_home: Path | None = None) -> Path:
+    archive_path = archive or elan_archive_path()
+    target = target_home or elan_home()
+    work_root = Path(tempfile.mkdtemp(prefix="elan-unpack-", dir=tmp_dir()))
+    try:
+        safe_extract(archive_path, work_root)
+        extracted = work_root / ".elan"
+        if not extracted.exists():
+            raise ValueError(f"Archive does not contain .elan/: {archive_path}")
+        return atomic_replace_dir(extracted, target)
+    finally:
+        remove_path(work_root)
+
+
+def install_elan(server: str | None = None, target_home: Path | None = None) -> Path:
+    target = target_home or elan_home()
+    if (target / "bin" / "elan").exists():
+        return target
+    get_elan(server)
+    return unpack_elan(elan_archive_path(), target)
+
+
+def check_elan(target_home: Path | None = None) -> str:
+    target = target_home or elan_home()
+    elan_bin = target / "bin" / "elan"
+    if not elan_bin.exists():
+        raise ValueError(f"elan not found: {elan_bin}")
+    result = subprocess.run([str(elan_bin), "--version"], text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "elan --version failed")
+    return result.stdout.strip()
+
+
+def pack_lean(version: str, source_home: Path | None = None) -> Path:
+    source = (source_home or elan_home()) / "toolchains" / toolchain_name(version)
+    return tar_directory(source, f".elan/toolchains/{source.name}", lean_archive_path(version))
+
+
+def get_lean(version: str, server: str | None = None) -> Path:
+    base = resolve_server(server)
+    if not base:
+        raise ValueError("No server configured. Use --server or leanup config set-server.")
+    return download_to(urljoin(base.rstrip("/") + "/", f"lean/{normalize_lean_version(version)}/toolchain.tar.gz"), lean_archive_path(version))
+
+
+def unpack_lean(version: str, archive: Path | None = None, target_home: Path | None = None) -> Path:
+    archive_path = archive or lean_archive_path(version)
+    home = target_home or elan_home()
+    work_root = Path(tempfile.mkdtemp(prefix="lean-unpack-", dir=tmp_dir()))
+    try:
+        safe_extract(archive_path, work_root)
+        toolchains_root = work_root / ".elan" / "toolchains"
+        candidates = [path for path in toolchains_root.iterdir() if path.is_dir()] if toolchains_root.exists() else []
+        if len(candidates) != 1:
+            raise ValueError(f"Archive must contain exactly one toolchain directory: {archive_path}")
+        target = home / "toolchains" / candidates[0].name
+        return atomic_replace_dir(candidates[0], target)
+    finally:
+        remove_path(work_root)
+
+
+def install_lean(version: str, server: str | None = None, target_home: Path | None = None) -> Path:
+    home = target_home or elan_home()
+    target = home / "toolchains" / toolchain_name(version)
+    if target.exists():
+        return target
+    base = resolve_server(server)
+    if base:
+        try:
+            get_lean(version, base)
+            return unpack_lean(version, lean_archive_path(version), home)
+        except requests.RequestException:
+            pass
+    elan_bin = home / "bin" / "elan"
+    if not elan_bin.exists():
+        raise ValueError(f"elan not found: {elan_bin}. Run leanup elan install first.")
+    result = subprocess.run([str(elan_bin), "toolchain", "install", f"leanprover/lean4:{normalize_lean_version(version)}"], text=True)
+    if result.returncode != 0:
+        raise RuntimeError("elan toolchain install failed")
+    return target
+
+
+def list_installed_lean(target_home: Path | None = None) -> list[str]:
+    root = (target_home or elan_home()) / "toolchains"
+    if not root.exists():
+        return []
+    return [child.name for child in sorted(root.iterdir()) if child.is_dir()]
+
+
+def check_lean(version: str, target_home: Path | None = None) -> str:
+    home = target_home or elan_home()
+    toolchain = home / "toolchains" / toolchain_name(version)
+    if not toolchain.exists():
+        raise ValueError(f"toolchain not found: {toolchain}")
+    lean_bin = toolchain / "bin" / "lean"
+    if not lean_bin.exists():
+        raise ValueError(f"lean not found: {lean_bin}")
+    result = subprocess.run([str(lean_bin), "--version"], text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "lean --version failed")
+    return result.stdout.strip()

--- a/leanup/ops/environment.py
+++ b/leanup/ops/environment.py
@@ -9,15 +9,13 @@ from urllib.parse import urljoin
 
 import requests
 
-from leanup.paths import cache_dir, elan_home, ensure_base_dirs, server_url, tmp_dir
+from leanup.paths import cache_dir, elan_home, ensure_base_dirs, server_url
 from leanup.repo.mathlib_cache import normalize_lean_version, remove_path
 
 
 def download_to(url: str, output_file: Path) -> Path:
     output_file.parent.mkdir(parents=True, exist_ok=True)
-    work_root = tmp_dir()
-    work_root.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(dir=work_root, prefix=f".{output_file.name}.", suffix=".tmp", delete=False) as handle:
+    with tempfile.NamedTemporaryFile(dir=output_file.parent, prefix=f".{output_file.name}.", suffix=".tmp", delete=False) as handle:
         temp_output = Path(handle.name)
     try:
         with requests.get(url, stream=True, timeout=120) as response:
@@ -60,9 +58,7 @@ def tar_directory(source_dir: Path, arcname: str, output_file: Path, exclude: se
     if not source_dir.exists():
         raise ValueError(f"Source directory not found: {source_dir}")
     output_file.parent.mkdir(parents=True, exist_ok=True)
-    work_root = tmp_dir()
-    work_root.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(dir=work_root, prefix=f".{output_file.name}.", suffix=".tmp", delete=False) as handle:
+    with tempfile.NamedTemporaryFile(dir=output_file.parent, prefix=f".{output_file.name}.", suffix=".tmp", delete=False) as handle:
         temp_output = Path(handle.name)
     try:
         with tarfile.open(temp_output, "w:gz", dereference=False) as tar:
@@ -121,15 +117,13 @@ def get_elan(server: str | None = None) -> Path:
 def unpack_elan(archive: Path | None = None, target_home: Path | None = None) -> Path:
     archive_path = archive or elan_archive_path()
     target = target_home or elan_home()
-    work_root = Path(tempfile.mkdtemp(prefix="elan-unpack-", dir=tmp_dir()))
-    try:
+    with tempfile.TemporaryDirectory(prefix="leanup-elan-unpack-") as work:
+        work_root = Path(work)
         safe_extract(archive_path, work_root)
         extracted = work_root / ".elan"
         if not extracted.exists():
             raise ValueError(f"Archive does not contain .elan/: {archive_path}")
         return atomic_replace_dir(extracted, target)
-    finally:
-        remove_path(work_root)
 
 
 def install_elan(server: str | None = None, target_home: Path | None = None) -> Path:
@@ -166,8 +160,8 @@ def get_lean(version: str, server: str | None = None) -> Path:
 def unpack_lean(version: str, archive: Path | None = None, target_home: Path | None = None) -> Path:
     archive_path = archive or lean_archive_path(version)
     home = target_home or elan_home()
-    work_root = Path(tempfile.mkdtemp(prefix="lean-unpack-", dir=tmp_dir()))
-    try:
+    with tempfile.TemporaryDirectory(prefix="leanup-lean-unpack-") as work:
+        work_root = Path(work)
         safe_extract(archive_path, work_root)
         toolchains_root = work_root / ".elan" / "toolchains"
         candidates = [path for path in toolchains_root.iterdir() if path.is_dir()] if toolchains_root.exists() else []
@@ -175,8 +169,6 @@ def unpack_lean(version: str, archive: Path | None = None, target_home: Path | N
             raise ValueError(f"Archive must contain exactly one toolchain directory: {archive_path}")
         target = home / "toolchains" / candidates[0].name
         return atomic_replace_dir(candidates[0], target)
-    finally:
-        remove_path(work_root)
 
 
 def install_lean(version: str, server: str | None = None, target_home: Path | None = None) -> Path:

--- a/leanup/paths.py
+++ b/leanup/paths.py
@@ -57,9 +57,6 @@ def config_dir() -> Path:
     return Path(get_config_value("LEANUP_CONFIG_DIR", home / "config") or home / "config").expanduser()
 
 
-def tmp_dir() -> Path:
-    home = leanup_home()
-    return Path(get_config_value("LEANUP_TMP_DIR", home / "tmp") or home / "tmp").expanduser()
 
 
 def elan_home() -> Path:
@@ -81,7 +78,6 @@ def ensure_base_dirs(home: Path | None = None) -> Path:
         "cache/serve/mathlib",
         "cache/local/mathlib",
         "cache/downloads",
-        "tmp",
         "logs",
         "state/locks",
     ]:
@@ -93,7 +89,6 @@ def ensure_base_dirs(home: Path | None = None) -> Path:
             f"LEANUP_HOME={root}\n"
             f"LEANUP_CACHE_DIR={root / 'cache'}\n"
             f"LEANUP_CONFIG_DIR={root / 'config'}\n"
-            f"LEANUP_TMP_DIR={root / 'tmp'}\n"
             f"LEANUP_ELAN_HOME={Path.home() / '.elan'}\n",
             encoding="utf-8",
         )

--- a/leanup/paths.py
+++ b/leanup/paths.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+
+
+def _read_env_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            values[key] = value
+    return values
+
+
+def default_home() -> Path:
+    return Path(os.environ.get("LEANUP_HOME", Path.home() / ".leanup")).expanduser()
+
+
+def env_file(home: Path | None = None) -> Path:
+    return (home or default_home()) / ".env"
+
+
+def load_dotenv(home: Path | None = None) -> dict[str, str]:
+    return _read_env_file(env_file(home))
+
+
+def get_config_value(name: str, default: str | Path | None = None) -> str | None:
+    if name in os.environ:
+        return os.environ[name]
+    values = load_dotenv()
+    if name in values:
+        return values[name]
+    if default is None:
+        return None
+    return str(default)
+
+
+def leanup_home() -> Path:
+    return Path(get_config_value("LEANUP_HOME", Path.home() / ".leanup") or Path.home() / ".leanup").expanduser()
+
+
+def cache_dir() -> Path:
+    home = leanup_home()
+    return Path(get_config_value("LEANUP_CACHE_DIR", home / "cache") or home / "cache").expanduser()
+
+
+def config_dir() -> Path:
+    home = leanup_home()
+    return Path(get_config_value("LEANUP_CONFIG_DIR", home / "config") or home / "config").expanduser()
+
+
+def tmp_dir() -> Path:
+    home = leanup_home()
+    return Path(get_config_value("LEANUP_TMP_DIR", home / "tmp") or home / "tmp").expanduser()
+
+
+def elan_home() -> Path:
+    default = os.environ.get("ELAN_HOME", str(Path.home() / ".elan"))
+    return Path(get_config_value("LEANUP_ELAN_HOME", default) or default).expanduser()
+
+
+def server_url() -> str | None:
+    return get_config_value("LEANUP_SERVER_URL")
+
+
+def ensure_base_dirs(home: Path | None = None) -> Path:
+    root = home or leanup_home()
+    for rel in [
+        "config",
+        "repos",
+        "cache/serve/elan/base",
+        "cache/serve/lean",
+        "cache/serve/mathlib",
+        "cache/local/mathlib",
+        "cache/downloads",
+        "tmp",
+        "logs",
+        "state/locks",
+    ]:
+        (root / rel).mkdir(parents=True, exist_ok=True)
+    env_path = root / ".env"
+    if not env_path.exists():
+        env_path.write_text(
+            "# LeanUp environment configuration\n"
+            f"LEANUP_HOME={root}\n"
+            f"LEANUP_CACHE_DIR={root / 'cache'}\n"
+            f"LEANUP_CONFIG_DIR={root / 'config'}\n"
+            f"LEANUP_TMP_DIR={root / 'tmp'}\n"
+            f"LEANUP_ELAN_HOME={Path.home() / '.elan'}\n",
+            encoding="utf-8",
+        )
+    return root
+
+
+def set_env_value(key: str, value: str, home: Path | None = None) -> Path:
+    root = home or leanup_home()
+    ensure_base_dirs(root)
+    path = root / ".env"
+    values = _read_env_file(path)
+    values[key] = value
+    lines = ["# LeanUp environment configuration"]
+    for item_key in sorted(values):
+        lines.append(f"{item_key}={values[item_key]}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path

--- a/leanup/repo/mathlib_cache.py
+++ b/leanup/repo/mathlib_cache.py
@@ -117,12 +117,16 @@ class MathlibCacheManager:
             return packages_dir
 
         version_root.mkdir(parents=True, exist_ok=True)
-        temp_root = version_root / ".packages.tmp"
-        remove_path(temp_root)
-        shutil.copytree(source_dir, temp_root, symlinks=True)
+        with tempfile.TemporaryDirectory(prefix=".packages.", suffix=".tmp", dir=version_root) as work:
+            temp_root = Path(work)
+            staged_packages = temp_root / "packages"
+            shutil.copytree(source_dir, staged_packages, symlinks=True)
 
-        remove_path(packages_dir)
-        temp_root.replace(packages_dir)
+            final_temp = version_root / ".packages.replace"
+            remove_path(final_temp)
+            staged_packages.replace(final_temp)
+            remove_path(packages_dir)
+            final_temp.replace(packages_dir)
         logger.info(f"Refreshed mathlib cache {normalized} from {source_dir}")
         return packages_dir
 
@@ -195,11 +199,8 @@ class MathlibCacheManager:
 
         parent_dir = target_packages_dir.parent
         parent_dir.mkdir(parents=True, exist_ok=True)
-        temp_root = Path(
-            tempfile.mkdtemp(prefix=f".{target_packages_dir.name}.", suffix=".tmp", dir=parent_dir)
-        )
-
-        try:
+        with tempfile.TemporaryDirectory(prefix=f".{target_packages_dir.name}.", suffix=".tmp", dir=parent_dir) as work:
+            temp_root = Path(work)
             with tarfile.open(archive_file, "r:gz") as tar:
                 self._safe_extract(tar, temp_root)
 
@@ -213,13 +214,9 @@ class MathlibCacheManager:
 
             remove_path(target_packages_dir)
             final_temp.replace(target_packages_dir)
-            remove_path(temp_root)
 
             logger.info(f"Extracted {archive_file} -> {target_packages_dir}")
             return target_packages_dir
-        except Exception:
-            remove_path(temp_root)
-            raise
 
     def fetch_packages(self, version: str, base_url: str) -> Path:
         archive = self.download_archive(version, self.build_archive_url(version, base_url))

--- a/leanup/repo/project_setup.py
+++ b/leanup/repo/project_setup.py
@@ -12,6 +12,7 @@ from leanup.repo.elan import ElanManager
 from leanup.repo.mathlib_cache import MathlibCacheManager, normalize_lean_version, remove_path
 from leanup.repo.manager import LeanRepo
 from leanup.utils.basic import working_directory
+from leanup.paths import cache_dir as leanup_cache_dir
 from leanup.utils.custom_logger import setup_logger
 
 logger = setup_logger("project_setup")
@@ -108,10 +109,13 @@ class LeanProjectSetup:
             cache_dir = config.mathlib_cache_dir if config.mathlib else None
 
             if config.mathlib and config.resolved_dependency_mode in {"symlink", "copy"}:
-                logger.info("Checking reusable mathlib package cache")
-                used_cache = self._prepare_mathlib_cache(config, project_dir)
-                if used_cache:
-                    self._write_manifest_from_packages(config, project_dir)
+                logger.info("Checking reusable local .lake cache")
+                used_cache = self._prepare_local_lake_cache(config, project_dir)
+                if not used_cache:
+                    logger.info("Checking reusable mathlib package cache")
+                    used_cache = self._prepare_mathlib_cache(config, project_dir)
+                    if used_cache:
+                        self._write_manifest_from_packages(config, project_dir)
 
             if config.mathlib and self._should_run_lake_update(config, project_dir):
                 logger.info("Running lake update")
@@ -364,6 +368,24 @@ class LeanProjectSetup:
         finally:
             if probe.exists():
                 probe.unlink()
+
+    def _local_lake_cache_dir(self, lean_version: str) -> Path:
+        return leanup_cache_dir() / "local" / "mathlib" / normalize_lean_version(lean_version) / ".lake"
+
+    def _prepare_local_lake_cache(self, config: SetupConfig, project_dir: Path) -> bool:
+        lake_cache = self._local_lake_cache_dir(config.lean_version)
+        if not lake_cache.exists():
+            return False
+
+        project_lake = project_dir / ".lake"
+        remove_path(project_lake)
+        project_lake.parent.mkdir(parents=True, exist_ok=True)
+        if config.resolved_dependency_mode == "symlink":
+            project_lake.symlink_to(lake_cache, target_is_directory=True)
+        else:
+            shutil.copytree(lake_cache, project_lake, symlinks=True)
+        self._write_manifest_from_packages(config, project_dir)
+        return True
 
     def _prepare_mathlib_cache(self, config: SetupConfig, project_dir: Path) -> bool:
         cache_dir = self.cache_manager.ensure_local_cache(config.lean_version)

--- a/leanup/repo/toolchain_cache.py
+++ b/leanup/repo/toolchain_cache.py
@@ -12,6 +12,7 @@ import requests
 from leanup.const import LEANUP_CACHE_DIR
 from leanup.repo.elan import ElanManager
 from leanup.repo.mathlib_cache import normalize_lean_version, remove_path
+from leanup.ops.environment import extract_tar_gz
 from leanup.utils.custom_logger import setup_logger
 
 logger = setup_logger("toolchain_cache")
@@ -101,8 +102,7 @@ class ToolchainCacheManager:
         archive_path = archive_path or self.get_base_archive_path()
         with tempfile.TemporaryDirectory(prefix=".elan-base.", dir=self.elan_home.parent) as work:
             temp_root = Path(work)
-            with tarfile.open(archive_path, "r:gz") as tar:
-                self._safe_extract(tar, temp_root)
+            extract_tar_gz(archive_path, temp_root)
             extracted = temp_root / ".elan"
             if not extracted.exists():
                 raise ValueError(f"Archive does not contain top-level .elan/ directory: {archive_path}")
@@ -136,8 +136,7 @@ class ToolchainCacheManager:
         archive_path = archive_path or self.get_toolchain_archive_path(version)
         with tempfile.TemporaryDirectory(prefix=".elan-toolchain.", dir=self.elan_home.parent) as work:
             temp_root = Path(work)
-            with tarfile.open(archive_path, "r:gz") as tar:
-                self._safe_extract(tar, temp_root)
+            extract_tar_gz(archive_path, temp_root)
             toolchains_root = temp_root / ".elan" / "toolchains"
             toolchain_dirs = [path for path in toolchains_root.iterdir() if path.is_dir()] if toolchains_root.exists() else []
             if len(toolchain_dirs) != 1:

--- a/leanup/repo/toolchain_cache.py
+++ b/leanup/repo/toolchain_cache.py
@@ -99,8 +99,8 @@ class ToolchainCacheManager:
 
     def unpack_base_archive(self, archive_path: Optional[Path] = None) -> Path:
         archive_path = archive_path or self.get_base_archive_path()
-        temp_root = Path(tempfile.mkdtemp(prefix=".elan-base.", dir=self.elan_home.parent))
-        try:
+        with tempfile.TemporaryDirectory(prefix=".elan-base.", dir=self.elan_home.parent) as work:
+            temp_root = Path(work)
             with tarfile.open(archive_path, "r:gz") as tar:
                 self._safe_extract(tar, temp_root)
             extracted = temp_root / ".elan"
@@ -111,12 +111,8 @@ class ToolchainCacheManager:
             extracted.replace(final_temp)
             remove_path(self.elan_home)
             final_temp.replace(self.elan_home)
-            remove_path(temp_root)
             logger.info(f"Unpacked base elan archive -> {self.elan_home}")
             return self.elan_home
-        except Exception:
-            remove_path(temp_root)
-            raise
 
     def pack_toolchain_archive(self, version: str) -> Path:
         toolchain_dir = self._resolve_installed_toolchain_dir(version)
@@ -138,8 +134,8 @@ class ToolchainCacheManager:
 
     def unpack_toolchain_archive(self, version: str, archive_path: Optional[Path] = None) -> Path:
         archive_path = archive_path or self.get_toolchain_archive_path(version)
-        temp_root = Path(tempfile.mkdtemp(prefix=".elan-toolchain.", dir=self.elan_home.parent))
-        try:
+        with tempfile.TemporaryDirectory(prefix=".elan-toolchain.", dir=self.elan_home.parent) as work:
+            temp_root = Path(work)
             with tarfile.open(archive_path, "r:gz") as tar:
                 self._safe_extract(tar, temp_root)
             toolchains_root = temp_root / ".elan" / "toolchains"
@@ -154,12 +150,8 @@ class ToolchainCacheManager:
             source_dir.replace(final_temp)
             remove_path(target_dir)
             final_temp.replace(target_dir)
-            remove_path(temp_root)
             logger.info(f"Unpacked toolchain archive -> {target_dir}")
             return target_dir
-        except Exception:
-            remove_path(temp_root)
-            raise
 
     def fetch_toolchain(self, version: str, base_url: str) -> Path:
         archive = self.download_toolchain_archive(version, self.build_toolchain_url(version, base_url))

--- a/tests/test_mathlib_cache_cli.py
+++ b/tests/test_mathlib_cache_cli.py
@@ -543,3 +543,46 @@ def test_mathlib_unpack_extracts_local_archive(tmp_path):
     assert result.exit_code == 0
     extracted = cache_root / "packages" / "v4.28.0" / "packages" / "mathlib" / "README.md"
     assert extracted.read_text(encoding="utf-8") == "cached\n"
+
+
+def test_mathlib_pack_source_lake_preserves_symlinks(tmp_path, monkeypatch):
+    runner = CliRunner()
+    leanup_home = tmp_path / "leanup"
+    workspace = tmp_path / "mathlib-workspace"
+    lake = workspace / ".lake"
+    lake.mkdir(parents=True)
+    (lake / "target").write_text("ok\n", encoding="utf-8")
+    (lake / "link").symlink_to("target")
+    monkeypatch.setenv("LEANUP_HOME", str(leanup_home))
+
+    result = runner.invoke(cli, ["mathlib", "pack", "v4.30.0", "--source", str(workspace)])
+
+    archive = leanup_home / "cache" / "serve" / "mathlib" / "v4.30.0" / "mathlib-lake.tar.gz"
+    assert result.exit_code == 0, result.output
+    assert archive.exists()
+    with tarfile.open(archive, "r:gz") as tar:
+        names = tar.getnames()
+        link = tar.getmember(".lake/link")
+    assert ".lake/target" in names
+    assert link.issym()
+
+
+def test_mathlib_unpack_lake_archive_preserves_symlinks(tmp_path, monkeypatch):
+    runner = CliRunner()
+    leanup_home = tmp_path / "leanup"
+    workspace = tmp_path / "mathlib-workspace"
+    lake = workspace / ".lake"
+    lake.mkdir(parents=True)
+    (lake / "target").write_text("ok\n", encoding="utf-8")
+    (lake / "link").symlink_to("target")
+    monkeypatch.setenv("LEANUP_HOME", str(leanup_home))
+
+    pack = runner.invoke(cli, ["mathlib", "pack", "v4.30.0", "--source", str(workspace)])
+    unpack = runner.invoke(cli, ["mathlib", "unpack", "v4.30.0"])
+
+    restored = leanup_home / "cache" / "local" / "mathlib" / "v4.30.0" / ".lake"
+    assert pack.exit_code == 0, pack.output
+    assert unpack.exit_code == 0, unpack.output
+    assert (restored / "target").exists()
+    assert (restored / "link").is_symlink()
+    assert (restored / "link").readlink() == Path("target")

--- a/tests/test_mathlib_cache_cli.py
+++ b/tests/test_mathlib_cache_cli.py
@@ -586,3 +586,5 @@ def test_mathlib_unpack_lake_archive_preserves_symlinks(tmp_path, monkeypatch):
     assert (restored / "target").exists()
     assert (restored / "link").is_symlink()
     assert (restored / "link").readlink() == Path("target")
+    assert not (leanup_home / "tmp").exists()
+    assert not list(restored.parent.glob("*.tmp"))

--- a/tests/test_resource_cli.py
+++ b/tests/test_resource_cli.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+import tarfile
+
+from click.testing import CliRunner
+
+from leanup.cli import cli
+
+
+def _create_elan_home(root: Path) -> Path:
+    elan_home = root / "elan"
+    (elan_home / "bin").mkdir(parents=True)
+    elan_bin = elan_home / "bin" / "elan"
+    elan_bin.write_text("#!/bin/sh\necho elan 0.0.0\n", encoding="utf-8")
+    elan_bin.chmod(0o755)
+    (elan_home / "settings.toml").write_text("default_toolchain = 'leanprover/lean4:v4.30.0'\n", encoding="utf-8")
+    return elan_home
+
+
+def _create_toolchain(elan_home: Path, version: str = "v4.30.0") -> Path:
+    toolchain = elan_home / "toolchains" / f"leanprover--lean4---{version}"
+    (toolchain / "bin").mkdir(parents=True)
+    lean_bin = toolchain / "bin" / "lean"
+    lean_bin.write_text(f"#!/bin/sh\necho Lean {version}\n", encoding="utf-8")
+    lean_bin.chmod(0o755)
+    target = toolchain / "lib-target"
+    target.write_text("target\n", encoding="utf-8")
+    (toolchain / "lib-link").symlink_to("lib-target")
+    return toolchain
+
+
+def test_init_creates_leanup_home(tmp_path):
+    runner = CliRunner()
+    home = tmp_path / "home"
+
+    result = runner.invoke(cli, ["init", "--home", str(home), "--server", "http://cache.local:8000"])
+
+    assert result.exit_code == 0, result.output
+    assert (home / ".env").exists()
+    assert (home / "cache" / "serve" / "elan" / "base").is_dir()
+    assert (home / "cache" / "local" / "mathlib").is_dir()
+    assert "LEANUP_SERVER_URL=http://cache.local:8000" in (home / ".env").read_text(encoding="utf-8")
+
+
+def test_elan_pack_excludes_toolchains_and_preserves_symlinks(tmp_path, monkeypatch):
+    runner = CliRunner()
+    leanup_home = tmp_path / "leanup"
+    elan_home = _create_elan_home(tmp_path)
+    _create_toolchain(elan_home)
+    (elan_home / "env-target").write_text("env\n", encoding="utf-8")
+    (elan_home / "env-link").symlink_to("env-target")
+    monkeypatch.setenv("LEANUP_HOME", str(leanup_home))
+
+    result = runner.invoke(cli, ["elan", "pack", "--elan-home", str(elan_home)])
+
+    archive = leanup_home / "cache" / "serve" / "elan" / "base" / "elan-base.tar.gz"
+    assert result.exit_code == 0, result.output
+    assert archive.exists()
+    with tarfile.open(archive, "r:gz") as tar:
+        names = tar.getnames()
+        link = tar.getmember(".elan/env-link")
+    assert ".elan/settings.toml" in names
+    assert not any(name.startswith(".elan/toolchains") for name in names)
+    assert link.issym()
+
+
+def test_lean_pack_and_unpack_preserves_toolchain_symlinks(tmp_path, monkeypatch):
+    runner = CliRunner()
+    leanup_home = tmp_path / "leanup"
+    elan_home = _create_elan_home(tmp_path)
+    _create_toolchain(elan_home)
+    restored_home = tmp_path / "restored-elan"
+    monkeypatch.setenv("LEANUP_HOME", str(leanup_home))
+
+    pack = runner.invoke(cli, ["lean", "pack", "v4.30.0", "--elan-home", str(elan_home)])
+    unpack = runner.invoke(cli, ["lean", "unpack", "v4.30.0", "--elan-home", str(restored_home)])
+
+    restored_toolchain = restored_home / "toolchains" / "leanprover--lean4---v4.30.0"
+    assert pack.exit_code == 0, pack.output
+    assert unpack.exit_code == 0, unpack.output
+    assert (restored_toolchain / "bin" / "lean").exists()
+    assert (restored_toolchain / "lib-link").is_symlink()
+    assert (restored_toolchain / "lib-link").readlink() == Path("lib-target")

--- a/tests/test_resource_cli.py
+++ b/tests/test_resource_cli.py
@@ -38,7 +38,21 @@ def test_init_creates_leanup_home(tmp_path):
     assert (home / ".env").exists()
     assert (home / "cache" / "serve" / "elan" / "base").is_dir()
     assert (home / "cache" / "local" / "mathlib").is_dir()
-    assert "LEANUP_SERVER_URL=http://cache.local:8000" in (home / ".env").read_text(encoding="utf-8")
+    assert not (home / "tmp").exists()
+    env_text = (home / ".env").read_text(encoding="utf-8")
+    assert "LEANUP_SERVER_URL=http://cache.local:8000" in env_text
+    assert "LEANUP_TMP_DIR" not in env_text
+
+
+def test_clean_command_is_not_public_cli():
+    runner = CliRunner()
+
+    help_result = runner.invoke(cli, ["--help"])
+    clean_result = runner.invoke(cli, ["clean", "tmp"])
+
+    assert help_result.exit_code == 0, help_result.output
+    assert "clean" not in help_result.output
+    assert clean_result.exit_code != 0
 
 
 def test_elan_pack_excludes_toolchains_and_preserves_symlinks(tmp_path, monkeypatch):
@@ -80,3 +94,24 @@ def test_lean_pack_and_unpack_preserves_toolchain_symlinks(tmp_path, monkeypatch
     assert (restored_toolchain / "bin" / "lean").exists()
     assert (restored_toolchain / "lib-link").is_symlink()
     assert (restored_toolchain / "lib-link").readlink() == Path("lib-target")
+
+def test_resource_unpack_does_not_leave_internal_tmp_dirs(tmp_path, monkeypatch):
+    runner = CliRunner()
+    leanup_home = tmp_path / "leanup"
+    source_home = _create_elan_home(tmp_path)
+    _create_toolchain(source_home)
+    restored_home = tmp_path / "restored-elan"
+    monkeypatch.setenv("LEANUP_HOME", str(leanup_home))
+
+    pack_elan = runner.invoke(cli, ["elan", "pack", "--elan-home", str(source_home)])
+    unpack_elan = runner.invoke(cli, ["elan", "unpack", "--elan-home", str(restored_home)])
+    pack_lean = runner.invoke(cli, ["lean", "pack", "v4.30.0", "--elan-home", str(source_home)])
+    unpack_lean = runner.invoke(cli, ["lean", "unpack", "v4.30.0", "--elan-home", str(restored_home)])
+
+    assert pack_elan.exit_code == 0, pack_elan.output
+    assert unpack_elan.exit_code == 0, unpack_elan.output
+    assert pack_lean.exit_code == 0, pack_lean.output
+    assert unpack_lean.exit_code == 0, unpack_lean.output
+    assert not (leanup_home / "tmp").exists()
+    assert not list(leanup_home.rglob("*unpack*"))
+


### PR DESCRIPTION
## Summary

Patch release for the v4.30.0 hitk -> bleu acceptance run.

- Use `pigz` automatically for tar.gz extraction when available.
- Use `pigz` automatically for large archive creation when possible.
- Stage directory unpack work on the same filesystem as the target to avoid cross-device `os.replace` failures.
- Allow `mathlib setup` to reuse a local `.lake` cache created by `mathlib unpack`, so consumer machines can restore Mathlib from an intranet archive without fetching from the public network.
- Bump version to `0.3.1`.

## Validation

- `python -m pytest tests -q` -> `78 passed`
- Targeted resource/mathlib/toolchain/setup tests -> `38 passed`

## Context

During the bleu restore test, `TemporaryDirectory()` under `/tmp` crossed filesystems when promoting into `$HOME`, causing `Invalid cross-device link`. This patch keeps scoped temporary cleanup behavior while staging directory promotion on the target filesystem.
